### PR TITLE
fix typo on ConnectAll

### DIFF
--- a/src/ConnectAll.js
+++ b/src/ConnectAll.js
@@ -7,7 +7,6 @@ import {
   resetValues as resetValuesAction,
 } from "./actions";
 import { defaultStoreLocation } from "./constants";
-import { create } from "domain";
 
 class ConnectAll extends Component {
   componentWillMount() {
@@ -48,7 +47,7 @@ const dispatchProps = {
 
 const mergeProps = (
   { values },
-  { initializesValueAction, updateValuesAction, resetValuesAction },
+  { initializeValuesAction, updateValuesAction, resetValuesAction },
   { initialValues, namespace, children },
 ) => ({
   initialize: () => {


### PR DESCRIPTION
I was confounded by this for a while.  The reason I fired up those other PRs and CRA was so that I could prove to myself that `ConnectAll` was working.  And it _**is**_ working in the example folder.  I have no idea why.

So I assumed I was doing something wrong in my repo, and finally I broke down and copied all the files into our components and used them directly.  That's when webstorm lint saved me.

--- 
Lint also told me to delete `domain.connect`.  Here's hoping that's cool. :crossed_fingers: .

