### PR TITLE
only initialize a namespace if initial values are given

### DIFF
--- a/src/ConnectAll.js
+++ b/src/ConnectAll.js
@@ -51,10 +51,12 @@ const mergeProps = (
   { initialValues, namespace, children },
 ) => ({
   initialize: () => {
-    initializeValuesAction({
-      namespace,
-      values: initialValues,
-    });
+    if (initialValues) {
+      initializeValuesAction({
+        namespace,
+        values: initialValues,
+      });
+    }
   },
   updateValues: updateFn => {
     updateValuesAction({ namespace, values: updateFn(values) });


### PR DESCRIPTION
I tried using multiple instances of a ConnectAll, with only one of them specifying `initialValues`.  If the instances that did not specify the prop were mounted last, they would overwrite the state with empty values.  Expected behavior is that one instance can provide `intitialValues`, and all other instances can read from that.

This change seems to work over in our big usage experiment.