### PR TITLE
Initialize to null is ok tho

### DIFF
--- a/src/ConnectAll.js
+++ b/src/ConnectAll.js
@@ -51,7 +51,7 @@ const mergeProps = (
   { initialValues, namespace, children },
 ) => ({
   initialize: () => {
-    if (initialValues) {
+    if (typeof initialValues !== "undefined") {
       initializeValuesAction({
         namespace,
         values: initialValues,


### PR DESCRIPTION
#6 was almost correct, except we _do_ want to initialize to `null` some times.

Once again, tested locally, and seems to resolve the `componentDidMount`-style fatal error.